### PR TITLE
2 10 0 - further corrections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:11-jre
 
 RUN apt-get update && apt-get install -y \
-  mysql-client
+  mariadb-client
 
 ENV	HIBISCUS_VERSION 2.8.10
 ENV	HIBISCUS_DOWNLOAD_SHA256 f517b6d079f30b7c42a7753a722012b5de2f3194

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ FROM openjdk:11-jre
 RUN apt-get update && apt-get install -y \
   mariadb-client
 
-ENV	HIBISCUS_VERSION 2.10.0
-ENV	HIBISCUS_DOWNLOAD_SHA256 55c5e89e7df6152464430cce6e8d6a171c5c5e3a
+ENV  HIBISCUS_VERSION 2.10.0
+ENV  HIBISCUS_DOWNLOAD_SHA256 '55c5e89e7df6152464430cce6e8d6a171c5c5e3a *hibiscus-server-2.10.0.zip'
 
-RUN curl -fsSL https://www.willuhn.de/products/hibiscus-server/releases/hibiscus-server-$HIBISCUS_VERSION.zip -o hibiscus-server.zip
-RUN echo "$HIBISCUS_DOWNLOAD_SHA256 hibiscus-server.zip" | sha1sum -c -
-RUN unzip hibiscus-server.zip -d /
-RUN rm hibiscus-server.zip
+RUN curl -fsSL https://www.willuhn.de/products/hibiscus-server/releases/hibiscus-server-$HIBISCUS_VERSION.zip -o hibiscus-server-$HIBISCUS_VERSION.zip
+RUN echo "$HIBISCUS_DOWNLOAD_SHA256" | sha1sum -c -
+RUN unzip hibiscus-server-$HIBISCUS_VERSION.zip -d /
+RUN rm hibiscus-server-$HIBISCUS_VERSION.zip
 
 RUN echo "Europe/Berlin" > /etc/timezone
 RUN dpkg-reconfigure -f noninteractive tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,10 @@ FROM openjdk:11-jre
 RUN apt-get update && apt-get install -y \
   mariadb-client
 
-ENV	HIBISCUS_RELEASE 2.10
 ENV	HIBISCUS_VERSION 2.10.0
-ENV	HIBISCUS_DOWNLOAD_SHA256 41c67808ec3b0f3c8df475f8457b0de8667c2b90
+ENV	HIBISCUS_DOWNLOAD_SHA256 55c5e89e7df6152464430cce6e8d6a171c5c5e3a
 
-RUN curl -fsSL https://www.willuhn.de/products/hibiscus-server/releases/$HIBISCUS_RELEASE/hibiscus-server-$HIBISCUS_VERSION.zip -o hibiscus-server.zip
+RUN curl -fsSL https://www.willuhn.de/products/hibiscus-server/releases/hibiscus-server-$HIBISCUS_VERSION.zip -o hibiscus-server.zip
 RUN echo "$HIBISCUS_DOWNLOAD_SHA256 hibiscus-server.zip" | sha1sum -c -
 RUN unzip hibiscus-server.zip -d /
 RUN rm hibiscus-server.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@ FROM openjdk:11-jre
 RUN apt-get update && apt-get install -y \
   mariadb-client
 
-ENV	HIBISCUS_VERSION 2.8.10
-ENV	HIBISCUS_DOWNLOAD_SHA256 f517b6d079f30b7c42a7753a722012b5de2f3194
+ENV	HIBISCUS_RELEASE 2.10
+ENV	HIBISCUS_VERSION 2.10.0
+ENV	HIBISCUS_DOWNLOAD_SHA256 41c67808ec3b0f3c8df475f8457b0de8667c2b90
 
-RUN curl -fsSL https://www.willuhn.de/products/hibiscus-server/releases/hibiscus-server-$HIBISCUS_VERSION.zip -o hibiscus-server.zip
+RUN curl -fsSL https://www.willuhn.de/products/hibiscus-server/releases/$HIBISCUS_RELEASE/hibiscus-server-$HIBISCUS_VERSION.zip -o hibiscus-server.zip
 RUN echo "$HIBISCUS_DOWNLOAD_SHA256 hibiscus-server.zip" | sha1sum -c -
 RUN unzip hibiscus-server.zip -d /
 RUN rm hibiscus-server.zip

--- a/create-tables.sh
+++ b/create-tables.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-mysql -h $DB_HOST -u $DB_USERNAME -p$DB_PASSWORD $DB_NAME < /hibiscus-server/plugins/hibiscus/sql/mysql-create.sql

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -e
+DB_PORT=${DB_PORT:-3306}
+USE_SSL=${USE_SSL:-"false"}
 
 cat > /hibiscus-server/cfg/de.willuhn.jameica.hbci.rmi.HBCIDBService.properties <<EOF
 database.driver=de.willuhn.jameica.hbci.server.DBSupportMySqlImpl
-database.driver.mysql.jdbcurl=jdbc\:mysql\://${DB_HOST}/${DB_NAME}?useUnicode\=Yes&characterEncoding\=ISO8859_1
+database.driver.mysql.jdbcdriver=org.mariadb.jdbc.Driver
+database.driver.mysql.jdbcurl=jdbc\:mysql\://${DB_HOST}:${DB_PORT}/${DB_NAME}?useUnicode\=Yes&characterEncoding\=ISO8859_1
 database.driver.mysql.username=${DB_USERNAME}
 database.driver.mysql.password=${DB_PASSWORD}
 EOF
@@ -14,6 +17,9 @@ listener.http.port=8080
 listener.http.auth=true
 listener.http.ssl=false
 EOF
+
+#cd /hibiscus-server/plugins/hibiscus/sql
+#mysql --user=$DB_USERNAME --password=$DB_PASSWORD --port=$DB_PORT --host=$DB_HOST $DB_NAME < mysql-create.sql
 
 cd /hibiscus-server
 java -Djava.net.preferIPv4Stack=true -Xmx512m -Djava.security.policy=file:///policy $_JCONSOLE -jar jameica-linux.jar -d -p $PASSWORD -f /srv/hibiscus

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,4 +16,4 @@ listener.http.ssl=false
 EOF
 
 cd /hibiscus-server
-java -Djava.net.preferIPv4Stack=true -Xmx512m -Djava.security.policy=file:///policy $_JCONSOLE -jar jameica-linux.jar -d -p $PASSWORD -f /srv/hibiscus
+/usr/bin/java -Djava.net.preferIPv4Stack=true -Xmx512m -Djava.security.policy=file:///policy $_JCONSOLE -jar jameica-linux.jar -d -p $PASSWORD -f /srv/hibiscus

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,4 +16,4 @@ listener.http.ssl=false
 EOF
 
 cd /hibiscus-server
-/usr/bin/java -Djava.net.preferIPv4Stack=true -Xmx512m -Djava.security.policy=file:///policy $_JCONSOLE -jar jameica-linux.jar -d -p $PASSWORD -f /srv/hibiscus
+java -Djava.net.preferIPv4Stack=true -Xmx512m -Djava.security.policy=file:///policy $_JCONSOLE -jar jameica-linux.jar -d -p $PASSWORD -f /srv/hibiscus


### PR DESCRIPTION
Das aktuelle OpenJRE 8 ist auf Debian Buster basiert. Darin wurde der MySQL-Client entfernt und durch MariaDB ersetzt. Nun habe ich auch dafür gesorgt, dass Hibiscus den richtigen Connector von MariaDB erhält.